### PR TITLE
IndexContent: catch network error

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -58,7 +58,6 @@ instance.interceptors.response.use(
     return response
   },
   (error) => {
-    message('网络错误或服务器异常,请稍后重试', 'error')
     return Promise.reject(error)
   }
 )

--- a/src/components/check/IndexContent.vue
+++ b/src/components/check/IndexContent.vue
@@ -130,18 +130,22 @@ const check = async () => {
 
   isComplete.value = false
 
-  const data = await api.check(text.value)
-  // const data = await api.allCheck(serverInfo, { data: { text: text.value }, method: 'post' })
-  response.rate = data.rate
-  response.articleArray = data.articleArray
-  response.startTime = data.startTime
-  response.lastUpdate = data.lastUpdate
+  try {
+    const data = await api.check(text.value)
+    // const data = await api.allCheck(serverInfo, { data: { text: text.value }, method: 'post' })
+    response.rate = data.rate
+    response.articleArray = data.articleArray
+    response.startTime = data.startTime
+    response.lastUpdate = data.lastUpdate
 
-  const tipMessage = (data.articleArray!.length == 0)
-    ? '没有找到重复的小作文捏'
-    : '点击复制以获取查重报告'
+    const tipMessage = (data.articleArray!.length == 0)
+      ? '没有找到重复的小作文捏'
+      : '点击复制以获取查重报告'
+    message(tipMessage)
+  } catch (err) {
+    message('网络错误或服务器异常,请稍后重试', 'error')
+  }
 
-  message(tipMessage)
   isComplete.value = true
 }
 


### PR DESCRIPTION
刚刚发现如果断网了，就会正常弹出一个错误alert，但是按钮却一直显示”查重中“

现在我用 try catch 把这个错误包起来了，但是一个空的 catch 看起来很奇怪... 所以要不然我们把 API 代码里面显示 error message 的代码去掉，只抛出错误，让每个组件自己决定怎么做（重置按钮状态，弹出提示等），如何？